### PR TITLE
Add basic Lifx API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,43 +41,43 @@ import {
 
 // // Tool handlers
 // server.setRequestHandler(ListToolsRequestSchema, async () => ({
-//     tools: [],
-//   }));
+//   tools: [],
+// }));
   
-//   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-//     try {
-//       const { name, arguments: args } = request.params;
+// server.setRequestHandler(CallToolRequestSchema, async (request) => {
+//   try {
+//     const { name, arguments: args } = request.params;
   
-//       if (!args) {
-//         throw new Error("No arguments provided");
-//       }
-  
-//       switch (name) {  
-//         case LIST_LIGHTS_TOOL.name: {
-//           return {
-//             content: [{ type: "text", text: "TODO" }],
-//             isError: false,
-//           };
-//         }
-  
-//         default:
-//           return {
-//             content: [{ type: "text", text: `Unknown tool: ${name}` }],
-//             isError: true,
-//           };
-//       }
-//     } catch (error) {
-//       return {
-//         content: [
-//           {
-//             type: "text",
-//             text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-//           },
-//         ],
-//         isError: true,
-//       };
+//     if (!args) {
+//       throw new Error("No arguments provided");
 //     }
-//   });
+  
+//     switch (name) {  
+//       case LIST_LIGHTS_TOOL.name: {
+//         return {
+//           content: [{ type: "text", text: "TODO" }],
+//           isError: false,
+//         };
+//       }
+  
+//       default:
+//         return {
+//           content: [{ type: "text", text: `Unknown tool: ${name}` }],
+//           isError: true,
+//         };
+//     }
+//   } catch (error) {
+//     return {
+//       content: [
+//         {
+//           type: "text",
+//           text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+//         },
+//       ],
+//       isError: true,
+//     };
+//   }
+// });
 
 // async function runServer() {
 //   const transport = new StdioServerTransport();
@@ -93,14 +93,28 @@ import {
 // @ts-ignore
 import Lifx from 'node-lifx-lan';
 
-Lifx.discover().then((device_list: any) => {
-    device_list.forEach((device: any) => {
-      console.log([
-        device['ip'],
-        device['mac'],
-        device['deviceInfo']['label']
-      ].join(' | '));
-    });
-  }).catch((error: any) => {
-    console.error(error);
+Lifx.discover().then((deviceList: any) => {
+  var toReturn: any;
+  deviceList.forEach((device: any) => {
+    console.log(JSON.stringify(device.deviceInfo.label));
+    if (device.deviceInfo.label == "Cooked Lamp") {
+      console.log("getting state...")
+      // toReturn = device.getLightState();
+      // todo: replace with original value: {"hue":0.00092,"saturation":0,"brightness":1,"kelvin":3200}
+      toReturn = device.setColor({
+        color: {
+          hue: 0.00092,
+          saturation: 0,
+          brightness: 1,
+          kelvin: 3200,
+        },
+        duration: 3000
+      });
+    }
   });
+  return toReturn;
+}).then((res: any) => {
+  console.log('Done! ' + JSON.stringify(res));
+}).catch((error: Error) => {
+  console.error(error);
+});

--- a/index.ts
+++ b/index.ts
@@ -90,31 +90,6 @@ import {
 //   process.exit(1);
 // });
 
-// @ts-ignore
-import Lifx from 'node-lifx-lan';
+import { setColorForLight } from "./src/lifx.js";
 
-Lifx.discover().then((deviceList: any) => {
-  var toReturn: any;
-  deviceList.forEach((device: any) => {
-    console.log(JSON.stringify(device.deviceInfo.label));
-    if (device.deviceInfo.label == "Cooked Lamp") {
-      console.log("getting state...")
-      // toReturn = device.getLightState();
-      // todo: replace with original value: {"hue":0.00092,"saturation":0,"brightness":1,"kelvin":3200}
-      toReturn = device.setColor({
-        color: {
-          hue: 0.00092,
-          saturation: 0,
-          brightness: 1,
-          kelvin: 3200,
-        },
-        duration: 3000
-      });
-    }
-  });
-  return toReturn;
-}).then((res: any) => {
-  console.log('Done! ' + JSON.stringify(res));
-}).catch((error: Error) => {
-  console.error(error);
-});
+await setColorForLight("Cooked Lamp")

--- a/index.ts
+++ b/index.ts
@@ -90,6 +90,31 @@ import {
 //   process.exit(1);
 // });
 
-import { setColorForLight } from "./src/lifx.js";
+import { getLights, getLightState, setColorForLight } from "./src/lifx.js";
 
-await setColorForLight("Cooked Lamp")
+async function main() {
+  try {
+    const lights = await getLights();
+    await setColorForLight("Cooked Lamp", {
+      hue: 0,
+      saturation: 0,
+      brightness: 0.91089,
+      kelvin: 3879,
+    });
+
+    for (const light of lights) {
+      const state = await getLightState(light.label);
+      
+      console.log(`Light: ${state.label}`);
+      console.log(`Location: ${state.location.label}`);
+      console.log(`Group: ${state.group.label}`);
+      console.log(`Is On: ${state.isOn}`);
+      console.log(`Color:`, state.color);
+      console.log('---');
+    }
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+main(); 

--- a/index.ts
+++ b/index.ts
@@ -8,84 +8,99 @@ import {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 
-const LIST_LIGHTS_TOOL: Tool = {
-  name: "lifx_lan_list_lights",
-  description:
-    "Searches for local businesses and places using Brave's Local Search API. " +
-    "Best for queries related to physical locations, businesses, restaurants, services, etc. " +
-    "Returns detailed information including:\n" +
-    "- Business names and addresses\n" +
-    "- Ratings and review counts\n" +
-    "- Phone numbers and opening hours\n" +
-    "Use this when the query implies 'near me' or mentions specific locations. " +
-    "Automatically falls back to web search if no local results are found.",
-  inputSchema: {
-    type: "object",
-    properties: {},
-    required: []
-  }
-};
+// const LIST_LIGHTS_TOOL: Tool = {
+//   name: "lifx_lan_list_lights",
+//   description:
+//     "Searches for local businesses and places using Brave's Local Search API. " +
+//     "Best for queries related to physical locations, businesses, restaurants, services, etc. " +
+//     "Returns detailed information including:\n" +
+//     "- Business names and addresses\n" +
+//     "- Ratings and review counts\n" +
+//     "- Phone numbers and opening hours\n" +
+//     "Use this when the query implies 'near me' or mentions specific locations. " +
+//     "Automatically falls back to web search if no local results are found.",
+//   inputSchema: {
+//     type: "object",
+//     properties: {},
+//     required: []
+//   }
+// };
 
-// Server implementation
-const server = new Server(
-  {
-    name: "lifx-lan-",
-    version: "0.1.0",
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  },
-);
+// // Server implementation
+// const server = new Server(
+//   {
+//     name: "lifx-lan-",
+//     version: "0.1.0",
+//   },
+//   {
+//     capabilities: {
+//       tools: {},
+//     },
+//   },
+// );
 
-// Tool handlers
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [],
-  }));
+// // Tool handlers
+// server.setRequestHandler(ListToolsRequestSchema, async () => ({
+//     tools: [],
+//   }));
   
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    try {
-      const { name, arguments: args } = request.params;
+//   server.setRequestHandler(CallToolRequestSchema, async (request) => {
+//     try {
+//       const { name, arguments: args } = request.params;
   
-      if (!args) {
-        throw new Error("No arguments provided");
-      }
+//       if (!args) {
+//         throw new Error("No arguments provided");
+//       }
   
-      switch (name) {  
-        case LIST_LIGHTS_TOOL.name: {
-          return {
-            content: [{ type: "text", text: "TODO" }],
-            isError: false,
-          };
-        }
+//       switch (name) {  
+//         case LIST_LIGHTS_TOOL.name: {
+//           return {
+//             content: [{ type: "text", text: "TODO" }],
+//             isError: false,
+//           };
+//         }
   
-        default:
-          return {
-            content: [{ type: "text", text: `Unknown tool: ${name}` }],
-            isError: true,
-          };
-      }
-    } catch (error) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-          },
-        ],
-        isError: true,
-      };
-    }
+//         default:
+//           return {
+//             content: [{ type: "text", text: `Unknown tool: ${name}` }],
+//             isError: true,
+//           };
+//       }
+//     } catch (error) {
+//       return {
+//         content: [
+//           {
+//             type: "text",
+//             text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+//           },
+//         ],
+//         isError: true,
+//       };
+//     }
+//   });
+
+// async function runServer() {
+//   const transport = new StdioServerTransport();
+//   await server.connect(transport);
+//   console.error("Lifx LAN MCP Server running on stdio");
+// }
+
+// runServer().catch((error) => {
+//   console.error("Fatal error running server:", error);
+//   process.exit(1);
+// });
+
+// @ts-ignore
+import Lifx from 'node-lifx-lan';
+
+Lifx.discover().then((device_list: any) => {
+    device_list.forEach((device: any) => {
+      console.log([
+        device['ip'],
+        device['mac'],
+        device['deviceInfo']['label']
+      ].join(' | '));
+    });
+  }).catch((error: any) => {
+    console.error(error);
   });
-
-async function runServer() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("Lifx LAN MCP Server running on stdio");
-}
-
-runServer().catch((error) => {
-  console.error("Fatal error running server:", error);
-  process.exit(1);
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.0.1"
+        "@modelcontextprotocol/sdk": "1.0.1",
+        "node-lifx-lan": "^0.5.1"
       },
       "bin": {
         "lifx-lan-mcp": "dist/index.js"
@@ -239,6 +240,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/node-lifx-lan": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/node-lifx-lan/-/node-lifx-lan-0.5.1.tgz",
+      "integrity": "sha512-bcihlWzQO8vEozB+6193NnE7dpKuEJE9pomsff7bjdxjvu2s7ECbOTIDWcl/jEfQXeXAc9/5axDZUHi/c5Wrdw==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "dist"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.0.1"
+    "@modelcontextprotocol/sdk": "1.0.1",
+    "node-lifx-lan": "^0.5.1"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/src/lifx.ts
+++ b/src/lifx.ts
@@ -1,27 +1,111 @@
 // @ts-ignore
 import Lifx from 'node-lifx-lan';
 
-export function setColorForLight(label: string): Promise<any> {
-  return Lifx.discover().then((deviceList: any) => {
-    var toReturn: any;
-    deviceList.forEach((device: any) => {
-      console.log(JSON.stringify(device.deviceInfo.label));
-      if (device.deviceInfo.label === label) {
-        // toReturn = device.getLightState();
-        toReturn = device.setColor({
-          color: {
-            hue: 0.00092,
-            saturation: 0,
-            brightness: 1,
-            kelvin: 3200,
-          },
-        });
-      }
+type Color = {
+  hue: number,
+  saturation: number, 
+  brightness: number,
+  kelvin?: number
+}
+
+type Light = {
+  label: string,
+  location: {
+    label: string
+  },
+  group: {
+    label: string
+  }
+}
+
+type LightState = Light & {
+  color: Color,
+  isOn: boolean
+}
+
+export function getLights(): Promise<Light[]> {
+  return Lifx.discover()
+    .then((deviceList: any) => {
+      return deviceList.map((device: any) => ({
+        label: device.deviceInfo.label,
+        location: {
+          label: device.deviceInfo.location.label
+        },
+        group: {
+          label: device.deviceInfo.group.label
+        }
+      }));
     });
-    return toReturn;
-  }).then((res: any) => {
-    console.log('Done! ' + JSON.stringify(res));
-  }).catch((error: Error) => {
-    console.error(error);
-  });
+}
+
+export function getLightState(label: string): Promise<LightState> {
+  return Lifx.discover()
+    .then((deviceList: any) => {
+      const device = deviceList.find((device: any) => device.deviceInfo.label === label);
+      
+      if (!device) {
+        throw new Error(`No LIFX device found with label: ${label}`);
+      }
+
+      return device.getLightState()
+        .then((state: any) => ({
+          label: device.deviceInfo.label,
+          location: {
+            label: device.deviceInfo.location.label
+          },
+          group: {
+            label: device.deviceInfo.group.label
+          },
+          color: {
+            hue: state.color.hue,
+            saturation: state.color.saturation,
+            brightness: state.color.brightness,
+            kelvin: state.color.kelvin
+          },
+          isOn: state.power === 1
+        }));
+    });
+}
+
+export function setColorForLight(label: string, color: Color, duration: number = 0): Promise<void> {
+  return Lifx.discover()
+    .then((deviceList: any) => {
+      const device = deviceList.find((device: any) => device.deviceInfo.label === label);
+      
+      if (!device) {
+        throw new Error(`No LIFX device found with label: ${label}`);
+      }
+
+      return device.setColor({
+        color,
+        duration,
+      });
+    })
+}
+
+export function turnOnLight(label: string, color: Color | undefined, duration = 0): Promise<void> {
+  return Lifx.discover()
+    .then((deviceList: any) => {
+      const device = deviceList.find((device: any) => device.deviceInfo.label === label);
+      
+      if (!device) {
+        throw new Error(`No LIFX device found with label: ${label}`);
+      }
+
+      return device.turnOn(color, duration);
+    })
+}
+
+
+export function turnOff(label: string, duration = 0): Promise<void> {
+  return Lifx.discover()
+    .then((deviceList: any) => {
+      const device = deviceList.find((device: any) => device.deviceInfo.label === label);
+      
+      if (!device) {
+        throw new Error(`No LIFX device found with label: ${label}`);
+      }
+
+      return device.turnOff(duration);
+    })
 }

--- a/src/lifx.ts
+++ b/src/lifx.ts
@@ -1,0 +1,27 @@
+// @ts-ignore
+import Lifx from 'node-lifx-lan';
+
+export function setColorForLight(label: string): Promise<any> {
+  return Lifx.discover().then((deviceList: any) => {
+    var toReturn: any;
+    deviceList.forEach((device: any) => {
+      console.log(JSON.stringify(device.deviceInfo.label));
+      if (device.deviceInfo.label === label) {
+        // toReturn = device.getLightState();
+        toReturn = device.setColor({
+          color: {
+            hue: 0.00092,
+            saturation: 0,
+            brightness: 1,
+            kelvin: 3200,
+          },
+        });
+      }
+    });
+    return toReturn;
+  }).then((res: any) => {
+    console.log('Done! ' + JSON.stringify(res));
+  }).catch((error: Error) => {
+    console.error(error);
+  });
+}


### PR DESCRIPTION
Using the [node-lifx-lan library](https://github.com/futomi/node-lifx-lan?tab=readme-ov-file#LifxLan-createDevice-method), I added basic APIs to:
- getLights: Retrieves a list of available LIFX lights with labels, locations, and groups.
- getLightState: Fetches the current state (color, on/off) of a LIFX light by its label.
- setColorForLight: Sets the color of a LIFX light by its label.
- turnOnLight: Turns on a LIFX light with an optional color.
- turnOff: Turns off a LIFX light.

Also adds basic MCP scaffolding, based off of https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search