### PR TITLE
Allow setting multiple lights at once

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -114,8 +114,7 @@ const TURN_ON_LIGHTS_TOOL: Tool = {
             type: "number",
             description: "Color temperature in Kelvin (optional, if not 3500 or previous value is used)"
           }
-        },
-        required: ["hue", "saturation", "brightness"]
+        }
       },
       duration: {
         type: "number",

--- a/index.ts
+++ b/index.ts
@@ -149,7 +149,7 @@ const TURN_OFF_LIGHTS_TOOL: Tool = {
 const server = new Server(
   {
     name: "lifx-lan-mcp",
-    version: "1.1.1",
+    version: "1.1.3",
   },
   {
     capabilities: {

--- a/index.ts
+++ b/index.ts
@@ -24,19 +24,20 @@ const LIST_LIGHTS_TOOL: Tool = {
   }
 };
 
-const GET_LIGHT_STATE_TOOL: Tool = {
-  name: "lifx_lan_get_light_state",
-  description: "Get the current state of a specific LIFX light, including its color, whether it's " +
-  "on or off, and other properties.",
+const GET_LIGHTS_STATE_TOOL: Tool = {
+  name: "lifx_lan_get_lights_state",
+  description: "Get the current state of one or more LIFX lights, including their colors, whether they're " +
+  "on or off, and what groups and locations they belong to (if any).",
   inputSchema: {
     type: "object",
     properties: {
-      label: {
-        type: "string",
-        description: "The label of the Lifx light to get the state for"
-      }
+      labels: {
+        type: "array",
+        items: { type: "string" },
+        description: "The label of one or more Lifx lights to set the color for. Array cannot be empty."
+      },
     },
-    required: ["label"]
+    required: ["labels"]
   }
 };
 
@@ -79,19 +80,20 @@ const SET_LIGHTS_COLOR_TOOL: Tool = {
         description: "Duration of the transition in milliseconds (optional, defaults to 0)"
       }
     },
-    required: ["label", "color"]
+    required: ["labels", "color"]
   }
 };
 
-const TURN_ON_LIGHT_TOOL: Tool = {
-  name: "lifx_lan_turn_on_light",
-  description: "Turn on a specific Lifx light, optionally at specific color.",
+const TURN_ON_LIGHTS_TOOL: Tool = {
+  name: "lifx_lan_turn_on_lights",
+  description: "Turn on one or more Lifx lights, optionally at specific color.",
   inputSchema: {
     type: "object",
     properties: {
-      label: {
-        type: "string",
-        description: "The label of the Lifx light to turn on"
+      labels: {
+        type: "array",
+        items: { type: "string" },
+        description: "The label of one or more Lifx lights to turn on the color for. Array cannot be empty."
       },
       color: {
         type: "object",
@@ -120,43 +122,44 @@ const TURN_ON_LIGHT_TOOL: Tool = {
         description: "Duration of the transition in milliseconds (optional, defaults to 0)"
       }
     },
-    required: ["label"]
+    required: ["labels"]
   }
 };
 
-const TURN_OFF_LIGHT_TOOL: Tool = {
-  name: "lifx_lan_turn_off_light",
-  description: "Turn off a specific Lifx light.",
+const TURN_OFF_LIGHTS_TOOL: Tool = {
+  name: "lifx_lan_turn_off_lights",
+  description: "Turn off one or more Lifx lights.",
   inputSchema: {
     type: "object",
     properties: {
-      label: {
-        type: "string",
-        description: "The label of the Lifx light to turn off"
+      labels: {
+        type: "array",
+        items: { type: "string" },
+        description: "The label of one or more Lifx lights to turn off. Array cannot be empty."
       },
       duration: {
         type: "number",
         description: "Duration of the transition in milliseconds (optional, defaults to 0)"
       }
     },
-    required: ["label"]
+    required: ["labels"]
   }
 };
 
 // Server implementation
 const server = new Server(
   {
-    name: "lifx-lan-",
-    version: "0.1.0",
+    name: "lifx-lan-mcp",
+    version: "1.1.1",
   },
   {
     capabilities: {
       tools: {
         [LIST_LIGHTS_TOOL.name]: LIST_LIGHTS_TOOL,
-        [GET_LIGHT_STATE_TOOL.name]: GET_LIGHT_STATE_TOOL,
+        [GET_LIGHTS_STATE_TOOL.name]: GET_LIGHTS_STATE_TOOL,
         [SET_LIGHTS_COLOR_TOOL.name]: SET_LIGHTS_COLOR_TOOL,
-        [TURN_ON_LIGHT_TOOL.name]: TURN_ON_LIGHT_TOOL,
-        [TURN_OFF_LIGHT_TOOL.name]: TURN_OFF_LIGHT_TOOL,
+        [TURN_ON_LIGHTS_TOOL.name]: TURN_ON_LIGHTS_TOOL,
+        [TURN_OFF_LIGHTS_TOOL.name]: TURN_OFF_LIGHTS_TOOL,
       },
     },
   },
@@ -166,10 +169,10 @@ const server = new Server(
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     LIST_LIGHTS_TOOL,
-    GET_LIGHT_STATE_TOOL,
+    GET_LIGHTS_STATE_TOOL,
     SET_LIGHTS_COLOR_TOOL,
-    TURN_ON_LIGHT_TOOL,
-    TURN_OFF_LIGHT_TOOL,
+    TURN_ON_LIGHTS_TOOL,
+    TURN_OFF_LIGHTS_TOOL,
   ],
 }));
   
@@ -191,12 +194,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case GET_LIGHT_STATE_TOOL.name: {
-        const { label } = args as { label: string };
-        const state = await getLightState(label);
+      case GET_LIGHTS_STATE_TOOL.name: {
+        const { labels } = args as { labels: string[] };
+        const states = await Promise.all(labels.map(label => getLightState(label)));
+        const state = Object.fromEntries(labels.map((label, i) => [label, states[i]]));
         const stateAsString = JSON.stringify(state);
         return {
-          content: [{ type: "text", text: `Light ${label} has state: ${stateAsString}` }],
+          content: [{ type: "text", text: `Lights ${labels} are in the following states: ${stateAsString}` }],
           isError: false,
         };
       }
@@ -214,24 +218,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case TURN_ON_LIGHT_TOOL.name: {
-        const { label, color, duration = 0 } = args as { 
-          label: string, 
+      case TURN_ON_LIGHTS_TOOL.name: {
+        const { labels, color, duration = 0 } = args as { 
+          labels: string[], 
           color?: { hue: number, saturation: number, brightness: number, kelvin?: number },
           duration?: number 
         };
-        await turnOnLight(label, color, duration);
+        await Promise.all(labels.map(label => turnOnLight(label, color, duration)));
         return {
-          content: [{ type: "text", text: `Successfully turned on light ${label}` }],
+          content: [{ type: "text", text: `Successfully turned on lights ${JSON.stringify(labels)}` }],
           isError: false,
         };
       }
 
-      case TURN_OFF_LIGHT_TOOL.name: {
-        const { label, duration = 0 } = args as { label: string, duration?: number };
-        await turnOff(label, duration);
+      case TURN_OFF_LIGHTS_TOOL.name: {
+        const { labels, duration = 0 } = args as { labels: string[], duration?: number };
+        await Promise.all(labels.map(label => turnOff(label, duration)));
         return {
-          content: [{ type: "text", text: `Successfully turned off light ${label}` }],
+          content: [{ type: "text", text: `Successfully turned off lights ${JSON.stringify(labels)}` }],
           isError: false,
         };
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lifx-lan-mcp",
   "description": "MCP server for Lifx LAN API integration",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "index.js",
   "author": "Simon Duchastel",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lifx-lan-mcp",
   "description": "MCP server for Lifx LAN API integration",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "author": "Simon Duchastel",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lifx-lan-mcp",
   "description": "MCP server for Lifx LAN API integration",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "index.js",
   "author": "Simon Duchastel",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lifx-lan-mcp",
   "description": "MCP server for Lifx LAN API integration",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "author": "Simon Duchastel",
   "license": "MIT",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,7 +13,7 @@ export async function discoverAndCacheDevices(): Promise<any[]> {
   deviceList.forEach((device: any) => {
     deviceCache[device.deviceInfo.label] = {
       mac: device.mac,
-      ip: device.address,
+      ip: device.ip,
       lastUpdated: now
     };
   });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -12,8 +12,8 @@ export async function discoverAndCacheDevices(): Promise<any[]> {
   // Update cache with all discovered devices
   deviceList.forEach((device: any) => {
     deviceCache[device.deviceInfo.label] = {
-      mac: device.deviceInfo.mac,
-      ip: device.deviceInfo.address,
+      mac: device.mac,
+      ip: device.address,
       lastUpdated: now
     };
   });

--- a/src/lifx.ts
+++ b/src/lifx.ts
@@ -1,5 +1,4 @@
 // @ts-ignore
-import Lifx from 'node-lifx-lan';
 import { Color, Light, LightState } from './types.js';
 import { discoverAndCacheDevices, getOrDiscoverDevice } from './cache.js';
 


### PR DESCRIPTION
Change a single label to a list of labels that get set in parallel when setting lights in the `setLight` call