### PR TITLE
Update http timeout and create new instances for MCP Server

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -46,14 +46,14 @@ export function parseConfig(args: string[]): ServerConfig | null | undefined {
   
 export async function runServer(
   config: ServerConfig = DEFAULT_CONFIG,
-  server: Server,
+  serverBuilder: () => Server,
 ) {  
   if (config.mode === 'stdio') {
     const transport = new StdioServerTransport();
-    await server.connect(transport);
+    await serverBuilder().connect(transport);
     console.log("Lifx LAN MCP Server running on stdio");
   } else if (config.mode === 'sse') {
-    const httpServer = new HttpServer(config, server);
+    const httpServer = new HttpServer(config, serverBuilder);
     await httpServer.start()
     console.log(`Lifx LAN MCP Server running on port ${config.port}`);
   } else {

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -53,6 +53,8 @@ export async function runServer(
     await serverBuilder().connect(transport);
     console.log("Lifx LAN MCP Server running on stdio");
   } else if (config.mode === 'sse') {
+    console.log("===WARNING===");
+    console.log("Running an MCP server over HTTP without authentication is very dangerous. Use at your own risk");
     const httpServer = new HttpServer(config, serverBuilder);
     await httpServer.start()
     console.log(`Lifx LAN MCP Server running on port ${config.port}`);

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -54,7 +54,8 @@ export async function runServer(
     console.log("Lifx LAN MCP Server running on stdio");
   } else if (config.mode === 'sse') {
     console.log("===WARNING===");
-    console.log("Running an MCP server over HTTP without authentication is very dangerous. Use at your own risk");
+    console.log("THIS IS DANGROUS. Running an MCP server over HTTP without authentication is very dangerous. Use at your own risk");
+    console.log("===WARNING===");
     const httpServer = new HttpServer(config, serverBuilder);
     await httpServer.start()
     console.log(`Lifx LAN MCP Server running on port ${config.port}`);

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -25,6 +25,10 @@ export class HttpServer {
     this.app = express();
     this.app.use(cors());
     this.app.use(express.json());
+    this.app.use((_, res, next) => {
+      res.setTimeout(SERVER_TIMEOUT_SECONDS);
+      next();
+    });
 
     this.mcpServerBuilder = mcpServerBuilder;
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -9,51 +9,94 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 
 export class HttpServer {
   private app: express.Application;
-  private mcpServer: Server;
+  private mcpServerBuilder: () => Server;
   private config: SSEConfig;
   private transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
   private transportsLegacy: { [sessionId: string]: SSEServerTransport } = {};
 
   constructor(
     config: SSEConfig,
-    mcpServer: Server,
+    mcpServerBuilder: () => Server,
 ) {
     this.config = config;
     this.app = express();
     this.app.use(cors());
     this.app.use(express.json());
 
-    this.mcpServer = mcpServer;
+    this.mcpServerBuilder = mcpServerBuilder;
 
-    this.setupRoutes(mcpServer);
+    this.setupRoutes();
   }
 
-  private setupRoutes(mcpServer: Server) {
+  private setupRoutes() {   
     // /sse and /message are the legacy routes, corresponding to the 2024-11-05 protocol version
     this.app.get('/sse', async (req: Request, res: Response) => {
-      const transport: SSEServerTransport = new SSEServerTransport('/message', res);
-      this.transportsLegacy[transport.sessionId] = transport;
+      console.log('Received GET request to /sse (establishing SSE stream)');
 
-      transport.onerror = (error: Error) => {
-        console.log(`Error: ${error}`)
-      };
+      try {
+        // Create a new SSE transport for the client
+        // The endpoint for POST messages is '/messages'
+        const transport = new SSEServerTransport('/messages', res);
 
-      await mcpServer.connect(transport);
-      console.log(`Opened connection for ${transport.sessionId}`)
-    });
-    this.app.post('/message', async (req: Request, res: Response) => {
-      const sessionId = req.query.sessionId as string;
-      const transport: SSEServerTransport = this.transportsLegacy[sessionId];
+        // Store the transport by session ID
+        const sessionId = transport.sessionId;
+        this.transportsLegacy[sessionId] = transport;
 
-      transport.onerror = (error: Error) => {
-        console.error(`Error: ${error}`)
-      };
-      transport.onclose = () => {
-        delete this.transportsLegacy[sessionId]
-        console.log(`Closed connection for ${sessionId}`)
+        // Set up onclose handler to clean up transport when closed
+        transport.onclose = () => {
+          console.log(`SSE transport closed for session ${sessionId}`);
+          delete this.transportsLegacy[sessionId];
+        };
+
+        // Connect the transport to a new instance of the MCP server
+        const server = this.mcpServerBuilder();
+        server.onclose = () => {
+          console.log(`MCP server closed for session ${sessionId}`);
+        }
+        await server.connect(transport);
+
+        // Start the SSE transport to begin streaming
+        // This sends an initial 'endpoint' event with the session ID in the URL
+        await transport.start();
+
+        console.log(`Established SSE stream with session ID: ${sessionId}`);
+      } catch (error) {
+        console.error('Error establishing SSE stream:', error);
+        if (!res.headersSent) {
+          res.status(500).send('Error establishing SSE stream');
+        }
       }
-  
-      await transport.handlePostMessage(req, res, req.body);
+    });
+
+    this.app.post('/messages', async (req: Request, res: Response) => {
+      console.log('Received POST request to /messages');
+
+      // Extract session ID from URL query parameter
+      // In the SSE protocol, this is added by the client based on the endpoint event
+      const sessionId = req.query.sessionId as string | undefined;
+
+      if (!sessionId) {
+        console.error('No session ID provided in request URL');
+        res.status(400).send('Missing sessionId parameter');
+        return;
+      }
+
+      const transport = this.transportsLegacy[sessionId];
+      if (!transport) {
+        console.error(`No active transport found for session ID: ${sessionId}`);
+        res.status(404).send('Session not found');
+        return;
+      }
+
+      try {
+        // Handle the POST message with the transport
+        await transport.handlePostMessage(req, res, req.body);
+      } catch (error) {
+        console.error('Error handling request:', error);
+        if (!res.headersSent) {
+          res.status(500).send('Error handling request');
+        }
+      }
     });
 
     // /mcp is the latest route as of 2025-04-21, corresponding to the 2025-03-26 protocol version
@@ -84,7 +127,7 @@ export class HttpServer {
           }
         };
 
-        await mcpServer.connect(transport);
+        await this.mcpServerBuilder().connect(transport);
       } else {
         // Invalid request
         res.status(400).json({
@@ -127,14 +170,8 @@ export class HttpServer {
   async start(): Promise<void> {
     return new Promise((resolve) => {
       this.app.listen(this.config.port, () => {
-        resolve();
+        console.log(`Listening on ${this.config.port}`)
       });
     });
   }
-
-  async close(): Promise<void> {
-    if (this.mcpServer) {
-      this.mcpServer.close();
-    }
-  }
-} 
+}

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -8,7 +8,7 @@ import { InMemoryEventStore } from "@modelcontextprotocol/sdk/examples/shared/in
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 
 
-const SERVER_TIMEOUT_SECONDS = 60 * 60; // 1hr timeout, given these streams might be long-lasting
+const SERVER_TIMEOUT_MS = 10 * 60 * 1000; // 10MIN timeout, given these streams might be long-lasting
 
 export class HttpServer {
   private app: express.Application;
@@ -26,7 +26,7 @@ export class HttpServer {
     this.app.use(cors());
     this.app.use(express.json());
     this.app.use((_, res, next) => {
-      res.setTimeout(SERVER_TIMEOUT_SECONDS);
+      res.setTimeout(SERVER_TIMEOUT_MS);
       next();
     });
 


### PR DESCRIPTION
Two notes:
- the way the SDK is built, the legacy SSE protocol requires a new instance of an MCP per transport because each time the transport closes (ie. a client disconnects) it closes the MCP server too. This seems crazy to me because then why have a separate transport class being tracked at all? I modified my code to create a new MCP instance per client (per /sse POST call) to accomodate this
- my express server kept closing the connection really quickly. I'm not sure why. Here I attempt to add a timeout value of 10min to force the connection to stay alive a long time. I mitigated on the client by sending a ping 1x/second to keep the connection open. It appears to not be working though.